### PR TITLE
XS Profile sanitizer environments

### DIFF
--- a/Sources/FuzzilliCli/Profiles/XSProfile.swift
+++ b/Sources/FuzzilliCli/Profiles/XSProfile.swift
@@ -19,7 +19,10 @@ let xsProfile = Profile(
         return ["-f"]
     },
 
-    processEnv: ["UBSAN_OPTIONS":"handle_segv=0"],
+    processEnv: ["UBSAN_OPTIONS":"handle_segv=0:symbolize=1:print_stacktrace=1:silence_unsigned_overflow=1",
+                 "ASAN_OPTIONS": "handle_segv=0:abort_on_error=1:symbolize=1",
+                 "MSAN_OPTIONS": "handle_segv=0:abort_on_error=1:symbolize=1",
+                 "MSAN_SYMBOLIZER_PATH": "/usr/bin/llvm-symbolizer"],
 
     codePrefix: """
                 function placeholder(){}


### PR DESCRIPTION
This PR sets sanitizer environments to ensure that:

* UBSAN produces symbolized and detailed stack traces.
* MSAN and UBSAN halt on error, and produced symbolized stack traces
* Set symbolizer path for MSAN

I believe this should not change default behavior on MacOS - ensures they are consistent across platforms.